### PR TITLE
Update .yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -9,6 +9,7 @@ ignore: |
   /venv
 
 rules:
+  document-start: disable
   line-length:
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: true


### PR DESCRIPTION
This PR adds `document-start: disable` to the .yamllint config file rules.