### PR TITLE
Ignore error for new coding standard

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@ count = True
 show-source = True
 statistics = True
 # ignore E203 (disagrees with PEP8 and Black) and W503 (outdated - replaced by W504)
-ignore = E203,W503
+ignore = E203, W503
 # potential to only check a specific list of rules not covered by Black
 # select = E9, F63, F7, F82
 exclude = 


### PR DESCRIPTION
Flake8 has two errors that conflict W503, W504. 

We should ignore W503.